### PR TITLE
check for zero value of time when fetching from file

### DIFF
--- a/source.go
+++ b/source.go
@@ -134,7 +134,7 @@ func (s *fileSource) Fetch(ifNewerThan time.Time) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ifNewerThan.Before(fi.ModTime()) {
+	if !ifNewerThan.IsZero() && ifNewerThan.Before(fi.ModTime()) {
 		return nil, ErrUnmodified
 	}
 	return f, nil


### PR DESCRIPTION
fileSource is so simple but alas, it has a serious bug.