### PR TITLE
fix(FromTarGz): use Extraction field, compare basename

### DIFF
--- a/keepcurrent_test.go
+++ b/keepcurrent_test.go
@@ -1,7 +1,9 @@
 package keepcurrent
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"crypto/rand"
 	"encoding/json"
 	"io"
@@ -202,4 +204,70 @@ func TestBackoffOnFail(t *testing.T) {
 	assert.EqualValues(t, 5, atomic.LoadInt32(&s.calls))
 	assert.EqualValues(t, 1, atomic.LoadInt32(&updates))
 	assert.EqualValues(t, 1, atomic.LoadInt32(&finalFailures))
+}
+
+// bytesSource is a Source that returns a fixed byte slice every Fetch.
+type bytesSource struct{ data []byte }
+
+func (b *bytesSource) Fetch(time.Time) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(b.data)), nil
+}
+
+// makeTarGz builds an in-memory .tar.gz containing a single file stored
+// under the given path (e.g. "dir/file") so tests can exercise the basename-
+// match path without shipping a fixture.
+func makeTarGz(t *testing.T, storedPath string, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     storedPath,
+		Mode:     0644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+		ModTime:  time.Now(),
+	}); err != nil {
+		t.Fatalf("tar header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("tar write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// Regression test for the two bugs fixed in PR #7: FromTarGz must extract
+// a file whose stored path includes a directory prefix (as MaxMind ships
+// its mmdb tarballs), matched by the basename the caller passes.
+func TestFromTarGzBasenameMatch(t *testing.T) {
+	want := []byte("hello world")
+	tgz := makeTarGz(t, "GeoLite2-City_20260116/GeoLite2-City.mmdb", want)
+
+	src := FromTarGz(&bytesSource{data: tgz}, "GeoLite2-City.mmdb")
+	rc, err := src.Fetch(time.Time{})
+	assert.NoError(t, err, "Fetch should find the file by basename")
+	if err != nil {
+		return
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// When the requested file isn't in the archive we should return a clear
+// error, rather than the silent "no extraction format" that hid the
+// original regression.
+func TestFromTarGzMissingFile(t *testing.T) {
+	tgz := makeTarGz(t, "some/other-file.txt", []byte("x"))
+	src := FromTarGz(&bytesSource{data: tgz}, "GeoLite2-City.mmdb")
+	_, err := src.Fetch(time.Time{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/source.go
+++ b/source.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -92,14 +93,20 @@ func (s *tarGzSource) Fetch(ifNewerThan time.Time) (io.ReadCloser, error) {
 	}
 	defer rc.Close()
 
+	// archives.CompressedArchive.Extract() reads ca.Extraction (not ca.Archival),
+	// and returns "no extraction format" if it's nil. Setting Archival here was a
+	// bug that made every Fetch() fail silently.
 	format := archives.CompressedArchive{
 		Compression: archives.Gz{},
-		Archival:    archives.Tar{},
+		Extraction:  archives.Tar{},
 	}
 
 	var buf []byte
 	err = format.Extract(context.Background(), rc, func(ctx context.Context, info archives.FileInfo) error {
-		if info.NameInArchive == s.expectedName {
+		// NameInArchive is the full stored path (e.g. "GeoLite2-City_20260116/GeoLite2-City.mmdb").
+		// Callers pass the basename, so compare on basename — mirrors the behavior of the
+		// archiver/v3-based implementation this replaced.
+		if path.Base(info.NameInArchive) == s.expectedName {
 			f, err := info.Open()
 			if err != nil {
 				return err


### PR DESCRIPTION
Two back-to-back bugs in the \`mholt/archiver\` → \`mholt/archives\` port (commit \`017d542\`), discovered while debugging why the lantern-box country tag was empty across the whole bandit fleet.

## Bug 1 — \"no extraction format\"

\`archives.CompressedArchive.Extract()\` reads the \`Extraction\` field, not \`Archival\`:

\`\`\`go
// archives/formats.go:285
if ca.Extraction == nil {
    return fmt.Errorf(\"no extraction format\")
}
\`\`\`

keepcurrent was setting \`Archival\` instead, so every \`Fetch()\` returned that error. Because \`keepcurrent.syncOnce\` feeds errors into \`OnSourceError\` (which is typically \`ExpBackoffThenFail(time.Minute, 30, ...)\`), the failure was **silently retried for up to 30 tries with exponential backoff** before any log line was emitted — the caller could wait >17 years for the final error.

## Bug 2 — basename vs full path

\`info.NameInArchive\` is the full stored path in the archive (e.g. \`GeoLite2-City_20260116/GeoLite2-City.mmdb\` as MaxMind ships it). Callers pass the basename (\`GeoLite2-City.mmdb\`), matching the \`archiver/v3\` behavior this replaced. Compare with \`path.Base()\` so these match.

## How this was found

lantern-box calls \`geo.FromWeb(\"https://lanterngeo.lantern.io/GeoLite2-City.mmdb.tar.gz\", \"GeoLite2-City.mmdb\", ...)\`. On every bandit VPS, the download was silently failing. Downstream effect: every \`proxy.io\` metric was tagged with \`geo.country.iso_code=\"\"\` (the default after \`*lookup.CountryCode\` returns empty when the db never loads), and the Bandwidth dashboard's country filter matched zero everywhere. Confirmed by running a minimal probe binary against a live VPS — reproduced both failures, then verified the fix extracts 63 MB cleanly in <2 s.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes (existing tests still OK)
- [x] Verified live against the real MaxMind tarball on a prod bandit VPS: extracts \`GeoLite2-City.mmdb\` (63417044 bytes) in 1.6 s
- [ ] Once merged, bump in lantern-box and rebuild packer image