### PR TITLE
fix: recover send-on-closed-channel panic in byteChannel sink

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -1,6 +1,7 @@
 package keepcurrent
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -72,7 +73,17 @@ func ToChannel(ch chan []byte) Sink {
 	return &byteChannel{ch}
 }
 
-func (s *byteChannel) UpdateFrom(r io.Reader) error {
+func (s *byteChannel) UpdateFrom(r io.Reader) (err error) {
+	// The channel is owned by the caller (see ToChannel) and may be closed
+	// concurrently — e.g. on shutdown or config reload — while a Runner is
+	// mid-sync. A send on a closed channel panics, which would crash the whole
+	// process; recover and surface it as a sink error instead (Runner reports
+	// sink errors via OnSinkError rather than dying).
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = fmt.Errorf("send on byte channel: %v", rec)
+		}
+	}()
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err

--- a/sink.go
+++ b/sink.go
@@ -77,11 +77,16 @@ func (s *byteChannel) UpdateFrom(r io.Reader) (err error) {
 	// The channel is owned by the caller (see ToChannel) and may be closed
 	// concurrently — e.g. on shutdown or config reload — while a Runner is
 	// mid-sync. A send on a closed channel panics, which would crash the whole
-	// process; recover and surface it as a sink error instead (Runner reports
-	// sink errors via OnSinkError rather than dying).
+	// process; recover *only that specific panic* and surface it as a sink
+	// error instead (Runner reports sink errors via OnSinkError rather than
+	// dying). Any other panic is re-raised so genuine bugs still surface.
 	defer func() {
 		if rec := recover(); rec != nil {
-			err = fmt.Errorf("send on byte channel: %v", rec)
+			if e, ok := rec.(error); ok && e.Error() == "send on closed channel" {
+				err = fmt.Errorf("byte channel sink: %w", e)
+				return
+			}
+			panic(rec)
 		}
 	}()
 	b, err := ioutil.ReadAll(r)

--- a/sink_test.go
+++ b/sink_test.go
@@ -1,0 +1,32 @@
+package keepcurrent
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Regression test for the "send on closed channel" crash (Freshdesk #176970):
+// the channel is owned by the caller and may be closed (shutdown / config
+// reload) while a Runner is mid-sync. UpdateFrom must surface that as an error
+// rather than panicking and crashing the whole process.
+func TestByteChannelClosedDoesNotPanic(t *testing.T) {
+	ch := make(chan []byte)
+	close(ch)
+	s := ToChannel(ch)
+	err := s.UpdateFrom(bytes.NewReader([]byte("hello")))
+	if err == nil {
+		t.Fatal("expected an error sending to a closed channel, got nil")
+	}
+}
+
+// A healthy send still delivers the data unchanged.
+func TestByteChannelDelivers(t *testing.T) {
+	ch := make(chan []byte, 1)
+	s := ToChannel(ch)
+	if err := s.UpdateFrom(bytes.NewReader([]byte("hello"))); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := <-ch; string(got) != "hello" {
+		t.Fatalf("got %q, want %q", got, "hello")
+	}
+}

--- a/sink_test.go
+++ b/sink_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-// Regression test for the "send on closed channel" crash (Freshdesk #176970):
-// the channel is owned by the caller and may be closed (shutdown / config
-// reload) while a Runner is mid-sync. UpdateFrom must surface that as an error
-// rather than panicking and crashing the whole process.
+// Regression test for the "send on closed channel" crash: the channel is owned
+// by the caller and may be closed (shutdown / config reload) while a Runner is
+// mid-sync. UpdateFrom must surface that as an error rather than panicking and
+// crashing the whole process.
 func TestByteChannelClosedDoesNotPanic(t *testing.T) {
 	ch := make(chan []byte)
 	close(ch)


### PR DESCRIPTION
## Problem

`byteChannel.UpdateFrom` did an unguarded send to a caller-owned channel:

```go
func (s *byteChannel) UpdateFrom(r io.Reader) error {
	b, err := ioutil.ReadAll(r)
	if err != nil { return err }
	s.ch <- b   // sink.go:80 — panics if ch was closed
	return nil
}
```

A `Runner` (`Start`) calls `syncOnce` → `UpdateFrom` on a ticker. The channel is **owned by the caller** (`ToChannel` takes a caller channel), and consumers close it on shutdown / config reload:
- `getlantern/fronted` — `fronted.go:257` (keeps the masquerade list current)
- `getlantern/radiance` — `kindling/dnstt/parser.go:162`

When a tick fires the send while/after the consumer has closed the channel, `s.ch <- b` panics with **`send on closed channel`**, which crashes the **whole process**.

Observed crashing the **macOS v9 client (9.1.9)** — four `Runner` goroutines panicked simultaneously on shutdown. User-visible as "beta cannot be used, and can't even submit an in-app report" (a crashed app can't upload the report). Freshdesk #176970 / lantern-forum-cn #1543.

## Fix

The sink can't know whether the caller's channel is closed, so make the send close-safe: recover the panic and return it as a **sink error**. `Runner.syncOnce` already treats sink failures as recoverable via `OnSinkError` (keepcurrent.go:128-130) — so a closed channel now degrades to a logged sink error instead of a process crash. No consumer changes required; fixes every consumer at once.

## Tests

Added `sink_test.go`:
- `TestByteChannelClosedDoesNotPanic` — send to a closed channel returns an error, no panic (regression).
- `TestByteChannelDelivers` — healthy send still delivers unchanged.

`go build`, `go vet`, and the full test suite pass.

## Notes

- This was **not** fixed on `main` before this PR, and it's **cross-platform** (keepcurrent + fronted run on every client), so any v9 build could hit the crash whenever fronted/dnstt reloads at the wrong instant — macOS just happened to capture the crash log.
- Optional follow-up (separate, not required to stop the crash): consumers could `Stop()` the Runner before `close(ch)` to coordinate shutdown cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
